### PR TITLE
Issue15 - Increasing mtcpclient test coverage

### DIFF
--- a/mtcpclient/calculate.go
+++ b/mtcpclient/calculate.go
@@ -17,7 +17,7 @@ type metricsCollectionStats struct {
 }
 
 func (gc GroupOfConnections) calculateMetricsReport(status tcpclient.ConnectionStatus) (mr metricsCollectionStats) {
-	// TODO: There's something i don't like... initiatlizing values in the first loop, and the standard deviation
+	// TODO: There's something i don't like... initializing values in the first loop, and the standard deviation
 	//  requiring an extra pass considering all items... i'd move initialization out of the loop, and maybe iterate
 	//  over a filtered list rather than several loops over the original one, and maybe use specific generic functions...
 	//  requires further thinking in any case
@@ -39,7 +39,9 @@ func (gc GroupOfConnections) calculateMetricsReport(status tcpclient.ConnectionS
 			}
 		}
 	}
-	mr.avg = mr.total / time.Duration(mr.numberOfConnections)
+	if mr.numberOfConnections > 0 {
+		mr.avg = mr.total / time.Duration(mr.numberOfConnections)
+	}
 	mr.stdDev = gc.calculateStdDev(status, mr)
 	return mr
 }

--- a/mtcpclient/calculate_test.go
+++ b/mtcpclient/calculate_test.go
@@ -6,6 +6,22 @@ import (
 	"time"
 )
 
+func TestCalculateMetricsReport(t *testing.T) {
+	var testedGroupOfConnections GroupOfConnections = []tcpclient.Connection{}
+	mr := testedGroupOfConnections.calculateMetricsReport(tcpclient.ConnectionEstablished)
+	var emptyCollectionMetricsStats metricsCollectionStats = metricsCollectionStats{
+		avg:        0,
+		min:        0,
+		max:        0,
+		total:        0,
+		stdDev:        0,
+		numberOfConnections: 0,
+	}
+	if mr != emptyCollectionMetricsStats {
+		t.Error("Empty group of connections should report a zeroed metrics report, and its returning", mr)
+	}
+}
+
 func TestCalculateStdDev(t *testing.T) {
 	var stdDevScenariosChecks = []struct {
 		scenarioDescription string
@@ -40,21 +56,21 @@ func TestCalculateStdDev(t *testing.T) {
 		var sum int
 		for i, connectionDuration := range test.durationsInSecs {
 			gc = append(gc, tcpclient.NewConnection(i, tcpclient.ConnectionEstablished,
-				time.Duration(connectionDuration)*time.Second))
+				time.Duration(connectionDuration) * time.Second))
 			sum += connectionDuration
 		}
 
 		mr := metricsCollectionStats{}
 		if len(test.durationsInSecs) != 0 {
 			mr = metricsCollectionStats{
-				avg: time.Duration(sum/len(test.durationsInSecs)) * time.Second,
+				avg: time.Duration(sum / len(test.durationsInSecs)) * time.Second,
 			}
 		}
 
 		stddev := gc.calculateStdDev(tcpclient.ConnectionEstablished, mr)
 
-		if stddev != time.Duration(test.expectedStdDev)*time.Second {
-			t.Error(test.scenarioDescription+", and its", stddev)
+		if stddev != time.Duration(test.expectedStdDev) * time.Second {
+			t.Error(test.scenarioDescription + ", and its", stddev)
 		}
 	}
 }

--- a/mtcpclient/calculate_test.go
+++ b/mtcpclient/calculate_test.go
@@ -40,6 +40,7 @@ func TestCalculateMetricsReport(t *testing.T) {
 			},
 		},
 		{
+			// TODO: We will need to extend this to cover a mix connections closed + established on closure, when the code supports it
 			scenarioDescription:        "Multiple connections with different statuses should generate a report that describes the metrics of the right subset",
 			groupOfConnectionsToReport: GroupOfConnections{
 				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500) * time.Millisecond),

--- a/mtcpclient/calculate_test.go
+++ b/mtcpclient/calculate_test.go
@@ -26,11 +26,11 @@ func TestCalculateMetricsReport(t *testing.T) {
 			},
 		},
 		{
-			scenarioDescription:        "Single connection should generate a report that describes its associated metric",
+			scenarioDescription: "Single connection should generate a report that describes its associated metric",
 			groupOfConnectionsToReport: GroupOfConnections{
-				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500) * time.Millisecond),
+				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500)*time.Millisecond),
 			},
-			tcpStatusToReport:          tcpclient.ConnectionEstablished,
+			tcpStatusToReport: tcpclient.ConnectionEstablished,
 			expectedReportWithoutStdDev: metricsCollectionStats{
 				avg:                 500 * time.Millisecond,
 				min:                 500 * time.Millisecond,
@@ -41,13 +41,13 @@ func TestCalculateMetricsReport(t *testing.T) {
 		},
 		{
 			// TODO: We will need to extend this to cover a mix connections closed + established on closure, when the code supports it
-			scenarioDescription:        "Multiple connections with different statuses should generate a report that describes the metrics of the right subset",
+			scenarioDescription: "Multiple connections with different statuses should generate a report that describes the metrics of the right subset",
 			groupOfConnectionsToReport: GroupOfConnections{
-				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500) * time.Millisecond),
-				tcpclient.NewConnection(1, tcpclient.ConnectionError, time.Duration(1) * time.Second),
-				tcpclient.NewConnection(2, tcpclient.ConnectionError, time.Duration(3) * time.Second),
+				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500)*time.Millisecond),
+				tcpclient.NewConnection(1, tcpclient.ConnectionError, time.Duration(1)*time.Second),
+				tcpclient.NewConnection(2, tcpclient.ConnectionError, time.Duration(3)*time.Second),
 			},
-			tcpStatusToReport:          tcpclient.ConnectionError,
+			tcpStatusToReport: tcpclient.ConnectionError,
 			expectedReportWithoutStdDev: metricsCollectionStats{
 				avg:                 2 * time.Second,
 				min:                 1 * time.Second,
@@ -62,7 +62,7 @@ func TestCalculateMetricsReport(t *testing.T) {
 		resultingReport := test.groupOfConnectionsToReport.calculateMetricsReport(test.tcpStatusToReport)
 		test.expectedReportWithoutStdDev.stdDev = test.groupOfConnectionsToReport.calculateStdDev(test.tcpStatusToReport, resultingReport)
 		if resultingReport != test.expectedReportWithoutStdDev {
-			t.Error(test.scenarioDescription + ", and its", resultingReport)
+			t.Error(test.scenarioDescription+", and its", resultingReport)
 		}
 	}
 }
@@ -102,21 +102,21 @@ func TestCalculateStdDev(t *testing.T) {
 		var sum int
 		for i, connectionDuration := range test.durationsInSecs {
 			gc = append(gc, tcpclient.NewConnection(i, tcpclient.ConnectionEstablished,
-				time.Duration(connectionDuration) * time.Second))
+				time.Duration(connectionDuration)*time.Second))
 			sum += connectionDuration
 		}
 
 		mr := metricsCollectionStats{}
 		if len(test.durationsInSecs) != 0 {
 			mr = metricsCollectionStats{
-				avg: time.Duration(sum / len(test.durationsInSecs)) * time.Second,
+				avg: time.Duration(sum/len(test.durationsInSecs)) * time.Second,
 			}
 		}
 
 		stddev := gc.calculateStdDev(tcpclient.ConnectionEstablished, mr)
 
-		if stddev != time.Duration(test.expectedStdDev) * time.Second {
-			t.Error(test.scenarioDescription + ", and its", stddev)
+		if stddev != time.Duration(test.expectedStdDev)*time.Second {
+			t.Error(test.scenarioDescription+", and its", stddev)
 		}
 	}
 }

--- a/mtcpclient/calculate_test.go
+++ b/mtcpclient/calculate_test.go
@@ -10,11 +10,11 @@ func TestCalculateMetricsReport(t *testing.T) {
 	var testedGroupOfConnections GroupOfConnections = []tcpclient.Connection{}
 	mr := testedGroupOfConnections.calculateMetricsReport(tcpclient.ConnectionEstablished)
 	var emptyCollectionMetricsStats metricsCollectionStats = metricsCollectionStats{
-		avg:        0,
-		min:        0,
-		max:        0,
-		total:        0,
-		stdDev:        0,
+		avg:                 0,
+		min:                 0,
+		max:                 0,
+		total:               0,
+		stdDev:              0,
 		numberOfConnections: 0,
 	}
 	if mr != emptyCollectionMetricsStats {
@@ -56,21 +56,21 @@ func TestCalculateStdDev(t *testing.T) {
 		var sum int
 		for i, connectionDuration := range test.durationsInSecs {
 			gc = append(gc, tcpclient.NewConnection(i, tcpclient.ConnectionEstablished,
-				time.Duration(connectionDuration) * time.Second))
+				time.Duration(connectionDuration)*time.Second))
 			sum += connectionDuration
 		}
 
 		mr := metricsCollectionStats{}
 		if len(test.durationsInSecs) != 0 {
 			mr = metricsCollectionStats{
-				avg: time.Duration(sum / len(test.durationsInSecs)) * time.Second,
+				avg: time.Duration(sum/len(test.durationsInSecs)) * time.Second,
 			}
 		}
 
 		stddev := gc.calculateStdDev(tcpclient.ConnectionEstablished, mr)
 
-		if stddev != time.Duration(test.expectedStdDev) * time.Second {
-			t.Error(test.scenarioDescription + ", and its", stddev)
+		if stddev != time.Duration(test.expectedStdDev)*time.Second {
+			t.Error(test.scenarioDescription+", and its", stddev)
 		}
 	}
 }

--- a/mtcpclient/reporting.go
+++ b/mtcpclient/reporting.go
@@ -43,6 +43,11 @@ func FinalMetricsReport(gc GroupOfConnections) (output string) {
 	// Report for Established connections
 	// TODO: remove duplication - this and the next block are almost equal. The MR structure could have a common
 	//  String() representation
+
+	if !(gc.AtLeastOneConnectionEstablished() || gc.AtLeastOneConnectionInError()) {
+		return "\n"
+	}
+
 	if gc.AtLeastOneConnectionEstablished() {
 		mr := gc.calculateMetricsReport(tcpclient.ConnectionEstablished)
 		output = "Response time stats for " + strconv.Itoa(mr.numberOfConnections) +

--- a/mtcpclient/reporting_test.go
+++ b/mtcpclient/reporting_test.go
@@ -1,13 +1,13 @@
 package mtcpclient_test
 
 import (
-	"testing"
-	"github.com/dachad/tcpgoon/tcpclient"
-	"time"
 	"github.com/dachad/tcpgoon/mtcpclient"
+	"github.com/dachad/tcpgoon/tcpclient"
+	"testing"
+	"time"
 )
 
-func TestFinalMetricsReport(t *testing.T)  {
+func TestFinalMetricsReport(t *testing.T) {
 	var finalMetricsReportScenariosChecks = []struct {
 		scenarioDescription        string
 		groupOfConnectionsToReport mtcpclient.GroupOfConnections
@@ -16,22 +16,22 @@ func TestFinalMetricsReport(t *testing.T)  {
 		{
 			scenarioDescription:        "Empty group of connections should report nothing",
 			groupOfConnectionsToReport: mtcpclient.GroupOfConnections{},
-			expectedReport: "\n",
+			expectedReport:             "\n",
 		},
 		{
-			scenarioDescription:        "Single connection should generate a report that describes its associated metric",
+			scenarioDescription: "Single connection should generate a report that describes its associated metric",
 			groupOfConnectionsToReport: mtcpclient.GroupOfConnections{
-				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500) * time.Millisecond),
+				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500)*time.Millisecond),
 			},
 			expectedReport: "Response time stats for 1 established connections min/avg/max/dev = 500ms/500ms/500ms/0s\n",
 		},
 		{
 			// TODO: We will need to extend this to cover a mix connections closed + established on closure, when the code supports it
-			scenarioDescription:        "Multiple connections with different statuses should generate a report that describes the metrics of the right subset",
+			scenarioDescription: "Multiple connections with different statuses should generate a report that describes the metrics of the right subset",
 			groupOfConnectionsToReport: mtcpclient.GroupOfConnections{
-				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500) * time.Millisecond),
-				tcpclient.NewConnection(1, tcpclient.ConnectionError, time.Duration(1) * time.Second),
-				tcpclient.NewConnection(2, tcpclient.ConnectionError, time.Duration(3) * time.Second),
+				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500)*time.Millisecond),
+				tcpclient.NewConnection(1, tcpclient.ConnectionError, time.Duration(1)*time.Second),
+				tcpclient.NewConnection(2, tcpclient.ConnectionError, time.Duration(3)*time.Second),
 			},
 			expectedReport: "Response time stats for 1 established connections min/avg/max/dev = 500ms/500ms/500ms/0s\n" +
 				"Time to error stats for 2 failed connections min/avg/max/dev = 1s/2s/3s/1s\n",
@@ -41,7 +41,7 @@ func TestFinalMetricsReport(t *testing.T)  {
 	for _, test := range finalMetricsReportScenariosChecks {
 		resultingReport := mtcpclient.FinalMetricsReport(test.groupOfConnectionsToReport)
 		if resultingReport != test.expectedReport {
-			t.Error(test.scenarioDescription + ", and it is:", resultingReport)
+			t.Error(test.scenarioDescription+", and it is:", resultingReport)
 		}
 	}
 }

--- a/mtcpclient/reporting_test.go
+++ b/mtcpclient/reporting_test.go
@@ -1,0 +1,47 @@
+package mtcpclient_test
+
+import (
+	"testing"
+	"github.com/dachad/tcpgoon/tcpclient"
+	"time"
+	"github.com/dachad/tcpgoon/mtcpclient"
+)
+
+func TestFinalMetricsReport(t *testing.T)  {
+	var finalMetricsReportScenariosChecks = []struct {
+		scenarioDescription        string
+		groupOfConnectionsToReport mtcpclient.GroupOfConnections
+		expectedReport             string
+	}{
+		{
+			scenarioDescription:        "Empty group of connections should report nothing",
+			groupOfConnectionsToReport: mtcpclient.GroupOfConnections{},
+			expectedReport: "\n",
+		},
+		{
+			scenarioDescription:        "Single connection should generate a report that describes its associated metric",
+			groupOfConnectionsToReport: mtcpclient.GroupOfConnections{
+				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500) * time.Millisecond),
+			},
+			expectedReport: "Response time stats for 1 established connections min/avg/max/dev = 500ms/500ms/500ms/0s\n",
+		},
+		{
+			// TODO: We will need to extend this to cover a mix connections closed + established on closure, when the code supports it
+			scenarioDescription:        "Multiple connections with different statuses should generate a report that describes the metrics of the right subset",
+			groupOfConnectionsToReport: mtcpclient.GroupOfConnections{
+				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500) * time.Millisecond),
+				tcpclient.NewConnection(1, tcpclient.ConnectionError, time.Duration(1) * time.Second),
+				tcpclient.NewConnection(2, tcpclient.ConnectionError, time.Duration(3) * time.Second),
+			},
+			expectedReport: "Response time stats for 1 established connections min/avg/max/dev = 500ms/500ms/500ms/0s\n" +
+				"Time to error stats for 2 failed connections min/avg/max/dev = 1s/2s/3s/1s\n",
+		},
+	}
+
+	for _, test := range finalMetricsReportScenariosChecks {
+		resultingReport := mtcpclient.FinalMetricsReport(test.groupOfConnectionsToReport)
+		if resultingReport != test.expectedReport {
+			t.Error(test.scenarioDescription + ", and it is:", resultingReport)
+		}
+	}
+}

--- a/mtcpclient/reporting_test.go
+++ b/mtcpclient/reporting_test.go
@@ -1,7 +1,6 @@
-package mtcpclient_test
+package mtcpclient
 
 import (
-	"github.com/dachad/tcpgoon/mtcpclient"
 	"github.com/dachad/tcpgoon/tcpclient"
 	"testing"
 	"time"
@@ -10,17 +9,17 @@ import (
 func TestFinalMetricsReport(t *testing.T) {
 	var finalMetricsReportScenariosChecks = []struct {
 		scenarioDescription        string
-		groupOfConnectionsToReport mtcpclient.GroupOfConnections
+		groupOfConnectionsToReport GroupOfConnections
 		expectedReport             string
 	}{
 		{
 			scenarioDescription:        "Empty group of connections should report nothing",
-			groupOfConnectionsToReport: mtcpclient.GroupOfConnections{},
+			groupOfConnectionsToReport: GroupOfConnections{},
 			expectedReport:             "\n",
 		},
 		{
 			scenarioDescription: "Single connection should generate a report that describes its associated metric",
-			groupOfConnectionsToReport: mtcpclient.GroupOfConnections{
+			groupOfConnectionsToReport: GroupOfConnections{
 				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500)*time.Millisecond),
 			},
 			expectedReport: "Response time stats for 1 established connections min/avg/max/dev = 500ms/500ms/500ms/0s\n",
@@ -28,7 +27,7 @@ func TestFinalMetricsReport(t *testing.T) {
 		{
 			// TODO: We will need to extend this to cover a mix connections closed + established on closure, when the code supports it
 			scenarioDescription: "Multiple connections with different statuses should generate a report that describes the metrics of the right subset",
-			groupOfConnectionsToReport: mtcpclient.GroupOfConnections{
+			groupOfConnectionsToReport: GroupOfConnections{
 				tcpclient.NewConnection(0, tcpclient.ConnectionEstablished, time.Duration(500)*time.Millisecond),
 				tcpclient.NewConnection(1, tcpclient.ConnectionError, time.Duration(1)*time.Second),
 				tcpclient.NewConnection(2, tcpclient.ConnectionError, time.Duration(3)*time.Second),
@@ -39,7 +38,7 @@ func TestFinalMetricsReport(t *testing.T) {
 	}
 
 	for _, test := range finalMetricsReportScenariosChecks {
-		resultingReport := mtcpclient.FinalMetricsReport(test.groupOfConnectionsToReport)
+		resultingReport := FinalMetricsReport(test.groupOfConnectionsToReport)
 		if resultingReport != test.expectedReport {
 			t.Error(test.scenarioDescription+", and it is:", resultingReport)
 		}

--- a/tcpclient/connectionsManagement_test.go
+++ b/tcpclient/connectionsManagement_test.go
@@ -17,7 +17,7 @@ func TestTCPConnectEstablished(t *testing.T) {
 
 	dispatcher := &tcpserver.Dispatcher{
 		Handlers: make(map[string]*tcpserver.Handler),
-		Lock: sync.RWMutex{},
+		Lock:     sync.RWMutex{},
 	}
 
 	runTCPServer := func() {

--- a/tcpclient/connectionsManagement_test.go
+++ b/tcpclient/connectionsManagement_test.go
@@ -15,7 +15,10 @@ func TestTCPConnectEstablished(t *testing.T) {
 	var host = "127.0.0.1"
 	var port = 55555
 
-	dispatcher := &tcpserver.Dispatcher{make(map[string]*tcpserver.Handler)}
+	dispatcher := &tcpserver.Dispatcher{
+		Handlers: make(map[string]*tcpserver.Handler),
+		Lock: sync.RWMutex{},
+	}
 
 	runTCPServer := func() {
 		t.Log("Starting TCP server...")

--- a/tcpserver/tcpserver.go
+++ b/tcpserver/tcpserver.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"net"
 	"strconv"
-	"time"
 	"sync"
+	"time"
 )
 
 // Handler : Struct

--- a/tcpserver/tcpserver.go
+++ b/tcpserver/tcpserver.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 	"time"
+	"sync"
 )
 
 // Handler : Struct
@@ -36,19 +37,23 @@ func (h *Handler) listen() {
 // Dispatcher : Struct with all the handlers
 type Dispatcher struct {
 	Handlers map[string]*Handler //`type:"map[ip]*Handler"`
+	Lock     sync.RWMutex
 }
 
 func (d *Dispatcher) addHandler(conn net.Conn) {
 	addr := conn.RemoteAddr().String()
 	handler := &Handler{conn, make(chan bool, 1)}
-	// TODO: this can generate concurrent writes against a map. This is not supported and generates
-	//  random errors
+
+	d.Lock.Lock()
 	d.Handlers[addr] = handler
+	d.Lock.Unlock()
 
 	go handler.listen()
 
 	<-handler.closed // when connection closed, remove handler from handlers
+	d.Lock.Lock()
 	delete(d.Handlers, addr)
+	d.Lock.Unlock()
 }
 
 // ListenHandlers : start listening on the handler

--- a/tcpserver/tcpserver_test.go
+++ b/tcpserver/tcpserver_test.go
@@ -12,7 +12,10 @@ var once sync.Once
 func tcpServer(t *testing.T) func() {
 	return func() {
 		t.Log("Starting TCP server")
-		dispatcher := &Dispatcher{make(map[string]*Handler)}
+		dispatcher := &Dispatcher{
+			Handlers: make(map[string]*Handler),
+			Lock: sync.RWMutex{},
+		}
 		if err := dispatcher.ListenHandlers(8888); err != nil {
 			t.Error("Could not start the TCP server", err)
 			return

--- a/tcpserver/tcpserver_test.go
+++ b/tcpserver/tcpserver_test.go
@@ -14,7 +14,7 @@ func tcpServer(t *testing.T) func() {
 		t.Log("Starting TCP server")
 		dispatcher := &Dispatcher{
 			Handlers: make(map[string]*Handler),
-			Lock: sync.RWMutex{},
+			Lock:     sync.RWMutex{},
 		}
 		if err := dispatcher.ListenHandlers(8888); err != nil {
 			t.Error("Could not start the TCP server", err)


### PR DESCRIPTION
Adding test coverage for all reporting functions in this package.

However, worth to say: there's a public one (returns strings), then a private (similar, but just returns the metrics struct) and a helper function (std dev calculator). I find the tests for the first two functions are a bit overlapping/duplicated (it just changes the format), and we have the typical controversia of.. should we test private functions? See https://stackoverflow.com/questions/105007/should-i-test-private-methods-or-only-public-ones . In any case, here they are... overall test coverage will increase a lot!